### PR TITLE
Fix problem with defaultCollapsed state when it is explicitly set to false

### DIFF
--- a/src/controls/accordion/Accordion.tsx
+++ b/src/controls/accordion/Accordion.tsx
@@ -16,7 +16,7 @@ export class Accordion extends React.Component<IAccordionProps, IAccordionState>
     super(props);
 
     this.state = {
-      expanded: props.defaultCollapsed ? !props.defaultCollapsed : false
+      expanded: props.defaultCollapsed == null ? false : !props.defaultCollapsed
     };
   }
 


### PR DESCRIPTION
Problem is described here: https://sharepoint.stackexchange.com/questions/268362/how-make-accordion-detail-list-with-ui-fabric-react

There is one problem with this code:
```
this.state = {
    expanded: props.defaultCollapsed ? !props.defaultCollapsed : false
};
```

With this condition button won't be expanded by default when defaultCollapsed is explicitly set to false (expanded will be also false in this case). I changed it like this:
```
this.state = {
    expanded: props.defaultCollapsed == null ? false : !props.defaultCollapsed
};
```
Condition "props.defaultCollapsed == null" will be true when defaultCollapsed = null or undefined. If defaultCollapsed is true or false - condition "props.defaultCollapsed == null" will be false and code will use "!props.defaultCollapsed" option.